### PR TITLE
set default figure size as well as paper size

### DIFF
--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -154,10 +154,12 @@ class MatlabKernel(MetaKernel):
             code = ["set(0, 'defaultfigurevisible', 'off')"]
         else:
             code = ["set(0, 'defaultfigurevisible', 'on')"]
-        size = "set(0, 'defaultfigurepaperposition', [0 0 %s %s])"
+        paper_size = "set(0, 'defaultfigurepaperposition', [0 0 %s %s])"
+        figure_size = "set(0, 'defaultfigureposition', [0 0 %s %s])"
         code += ["set(0, 'defaultfigurepaperunits', 'inches')",
                  "set(0, 'defaultfigureunits', 'inches')",
-                 size % (int(width) / 150., int(height) / 150.)]
+                 paper_size % (int(width) / 150., int(height) / 150.),
+                 figure_size % (int(width) / 150., int(height) / 150.)]
         if sys.platform == 'darwin' and self._matlab.name == 'octave':
             code + ['setenv("GNUTERM", "X11")']
             if settings['backend'] != 'inline':


### PR DESCRIPTION
Greetings!

I'm working with matlab_kernel via pymatbridge to Matlab 2016a on Linux Mint.

I had some trouble with plotting.  I think I fixed the issue and want to offer up this patch.

`plot()` and other figure-making commands were causing a Matlab `imwrite()` error about the figure image being way too amusingly huge:
  http://www.mathworks.com/matlabcentral/newsreader/view_thread/327812

This happened with or without a `--size` argument to the `%plot` magic.  I could work around this by opening a `figure()` explicitly and setting a small `Position`, like `[0 0 100 100]` in pixel units.

So I think the fix is just a matter of setting the default figure size before plotting -- which you're already doing this in the `MatlabKernel`, by setting the `defaultfigurepaperposition`.  I found I had to set the `defaultfigureposition` as well, to make the error go away.

Maybe the default figure sizing behavior has silently changed between Matlab versions?

With this patch, I can execute the `matlab_kernel.ipynb` example, and the figures come out looking like the originals saved in the notebook file.
