### PR TITLE
BUGFIX: Matlab completion now works with structs

### DIFF
--- a/matlab_kernel/toolbox/do_matlab_complete.m
+++ b/matlab_kernel/toolbox/do_matlab_complete.m
@@ -3,10 +3,10 @@ function do_matlab_complete(substring)
 %   do_matlab_complete(substring) prints out the tab completion options for the
 %   string `substring`, one per line. This required evaluating some undocumented
 %   internal matlab code in the "base" workspace.
-% 
-%	Only MATLAB versions R2013a, R2014b, and R2015a were available for testing.
-%	This function is probably incompatible with some or many other releases, as
-%	the undocumented features it relies on are subject to change without notice.
+%
+%   Only MATLAB versions R2013a, R2014b, and R2015a were available for testing.
+%   This function is probably incompatible with some or many other releases, as
+%   the undocumented features it relies on are subject to change without notice.
 
 % grep'ing MATLAB R2014b for "tabcomplet" and dumping the symbols of the ELF
 % files that match suggests that the internal tab completion is implemented in
@@ -18,11 +18,11 @@ function do_matlab_complete(substring)
 
 % Trial and error reveals likely function signatures for certain MATLAB versions
 % R2014b and R2015a:
-% 	mtFindAllTabCompletions(String substring, int len, int offset)
-%	where `substring` is the string to be completed, `len` is the length of the
-%	string, and the first `offset` values returned by the engine are ignored.
+%   mtFindAllTabCompletions(String substring, int len, int offset)
+%   where `substring` is the string to be completed, `len` is the length of the
+%   string, and the first `offset` values returned by the engine are ignored.
 % R2013a:
-%	mtFindAllTabCompletions(String substring, int offset [optional])
+%   mtFindAllTabCompletions(String substring, int offset [optional])
 
 len = length(substring);
 offset = 0;
@@ -32,18 +32,25 @@ if verLessThan('MATLAB','8.4')
     args = sprintf('''%s'', %g', substring, offset);
 else
     % verified for R2014b, 2015a
-	args = sprintf('''%s'', %g, %g', substring, len, offset);
+    args = sprintf('''%s'', %g, %g', substring, len, offset);
 end
 
-
+% variables must be name-mangled to prevent collisions with user variables
+% because this code will be executed in the user's actual workspace
 get_completions = [ ...
     'matlabMCRinstance_avoid_name_collisions = com.mathworks.jmi.MatlabMCR;' ...
-    'completions_output = matlabMCRinstance_avoid_name_collisions.mtFindAllTabCompletions(' ...
-    args ');' ...
-    'for i=1:length(completions_output);' ...
-    '    fprintf(1, ''%s\n'', char(completions_output(i)));' ...
+    'completions_output_avoid_name_collisions = ' ...
+    '    matlabMCRinstance_avoid_name_collisions.mtFindAllTabCompletions(' ...
+            args ...
+         ');' ...
+    'prefix_avoid_name_collisions = get_completions_prefix(''' substring ''');' ...
+    'for i=1:length(completions_output_avoid_name_collisions);' ...
+    '    fprintf(1, ''%s%s\n'', prefix_avoid_name_collisions, ' ...
+    '            char(completions_output_avoid_name_collisions(i)));' ...
     'end;' ...
-    'clear(''matlabMCRinstance_avoid_name_collisions'', ''completions_output'');' ];
+    'clear(''matlabMCRinstance_avoid_name_collisions'', ' ...
+    '      ''completions_output_avoid_name_collisions'', ' ...
+    '      ''prefix_avoid_name_collisions'');' ];
 
 try
     evalin('base', get_completions);

--- a/matlab_kernel/toolbox/get_completions_prefix.m
+++ b/matlab_kernel/toolbox/get_completions_prefix.m
@@ -1,0 +1,24 @@
+function prefix = get_completions_prefix(substr)
+%get_completions_prefix  shared prefix for completion results
+%   prefix = get_completions_prefix(substr) will return the prefix that needs
+%   to be prepended to the results of mtFindAllTabCompletions in order for
+%   Python's MetaKernel to use those results correctly. For now, this simply
+%   fixes a problem where MetaKernel framework expects
+%   do_matlab_complete('some_struct.long') to return
+%   `some_struct.long_fieldname`, but mtFindAllTabCompletions returns
+%   `long_fieldname` instead in this case.
+    prefix = '';
+    period_ind = find(substr == '.');
+    if isempty(period_ind)
+        return;
+    end
+    needs_prefix = false;
+    try
+        needs_prefix = evalin('base', ['isstruct(' substr(1:period_ind(1)-1) ')']);
+    catch
+    end
+    if needs_prefix
+        prefix = substr(1:period_ind(1));
+    end
+end
+


### PR DESCRIPTION
This patch should fix #52.

The problem was that the MetaKernel framework expects `do_matlab_complete('some_struct.long')` to return `'some_struct.long_fieldname'`, but mtFindAllTabCompletions returns `'long_fieldname'` instead.

This was fixed by asking do_matlab_complete.m to manually re-add the prefix. Matlab's isstruct function is used to make sure that the prefix that's being added back is actually a struct, instead of trying to use regular expressions to find the prefix, since that prevents corner cases where filenames that are valid Matlab identifiers are confused for structs that don't exist.

In practice, this means autocompletion will work correctly on `test.p[TAB]` whether `test.py` is a script in the current directory, a field `py` of the struct `test`, or both.

Also corrected some tab/spaces inconsistencies in the relevant files, and did some more name mangling to make sure that `evalin(base, ...` doesn't cause any problems if the user has a variable named e.g. `completions_output`. 