### PR TITLE
changed requirement Python 3.5 -> Python 3.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
 |Python35|
 
-.. |Python35| image:: https://img.shields.io/badge/python-3.5-blue.svg
+.. |Python35| image:: https://img.shields.io/badge/python-3.x-blue.svg
 
 A Jupyter/IPython kernel for Matlab
 ===================================
 
 This requires `Jupyter Notebook <http://jupyter.readthedocs.org/en/latest/install.html>`_
-with Python 3.5, and the
+with Python 3.x, and the
 `Matlab engine for Python <https://www.mathworks.com/help/matlab/matlab-engine-for-python.html>`_.
 
 To install::

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import versioneer
 
 
 if __name__ == "__main__":
-    if sys.version_info < (3, 5):
-        raise ImportError("matlab_kernel requires Python>=3.5")
+    if sys.version_info.major < 3:
+        raise ImportError("matlab_kernel requires Python>=3.3")
 
     setup(name="matlab_kernel",
           author="Steven Silvester, Antony Lee",


### PR DESCRIPTION
As noted in #59 ([comment](https://github.com/Calysto/matlab_kernel/issues/59#issuecomment-247931251)), at least the Windows version of Matlab R2016a only allows installation of its python engine in Python <= 3.4. This PR accomodates that by changing matlab_kernel's required Python version.