### PR TITLE
Include a fallback to start_matlab()

### DIFF
--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -45,7 +45,10 @@ class MatlabKernel(MetaKernel):
 
     def __init__(self, *args, **kwargs):
         super(MatlabKernel, self).__init__(*args, **kwargs)
-        self._matlab = matlab.engine.start_matlab()
+        try:
+            self._matlab = matlab.engine.start_matlab()
+        except matlab.engine.EngineError:
+            self._matlab = matlab.engine.connect_matlab()
         self._first = True
         self._validated_plot_settings = {
             "backend": "inline",
@@ -200,7 +203,13 @@ class MatlabKernel(MetaKernel):
 
     def restart_kernel(self):
         self._matlab.exit()
-        self._matlab = matlab.engine.start_matlab()
+        try:
+            self._matlab = matlab.engine.start_matlab()
+        except matlab.engine.EngineError:
+            # This isn't a true restart
+            self._matlab = None  # disconnect from engine
+            self._matlab = matlab.engine.connect_matlab()  # re-connect
+            self._matlab.clear('all')  # clear all content 
         self._first = True
 
     def do_shutdown(self, restart):


### PR DESCRIPTION
Falls back to `connect_matlab()` if `start_matlab()` fails

Note:
- restart kernel is in this case not really a restart - it re-connects to the matlab installation and clears the matlab workspace
- It currently doesn't warn the user that an existing matlab instance is being used. However, I think this is actually OK, since for this to work users actually need to run matlab and explicitly call `matlab.engine.shareEngine`, so they should already be aware that they're using an existing engine

This closes #80 