### PR TITLE
change \\ to /

### DIFF
--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -100,7 +100,7 @@ class MatlabKernel(MetaKernel):
                             "arrayfun("
                                 "@(h, i) print(h, sprintf('{}/%i', i), '-d{}', '-r{}'),"
                                 "get(0, 'children'), (1:{})')".format(
-                                    tmpdir,
+                                    '/'.join(tmpdir.split(os.sep)),
                                     settings["format"],
                                     settings["resolution"],
                                     nfig),


### PR DESCRIPTION
This solves an error related to windows directory when plotting.
Only tested on windows.