### PR TITLE
Fix issue #121 and #123

### DIFF
--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -249,8 +249,8 @@ class MatlabKernel(MetaKernel):
 
     def _execute_async(self, code):
         try:
-            with pipes(stdout=_PseudoStream(partial(self.Print, sep="", end="")),
-                stderr=_PseudoStream(partial(self.Error, sep="", end=""))):
+            with pipes(stdout=_PseudoStream(partial(self.Print, end="")),
+                stderr=_PseudoStream(partial(self.Error, end=""))):
                 kwargs = { 'nargout': 0, 'async': True }
                 future = self._matlab.eval(code, **kwargs)
                 future.result()

--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -257,7 +257,7 @@ class MatlabKernel(MetaKernel):
         except (SyntaxError, MatlabExecutionError, KeyboardInterrupt) as exc:
             pass
             #stdout = exc.args[0]
-            #return ExceptionWrapper("Error", "-1", stdout)
+            #return ExceptionWrapper("Error", -1, stdout)
 
     def _execute_sync(self, code):
         out = StringIO()
@@ -269,7 +269,7 @@ class MatlabKernel(MetaKernel):
         except (SyntaxError, MatlabExecutionError) as exc:
             stdout = exc.args[0]
             self.Error(stdout)
-            return ExceptionWrapper("Error", "-1", stdout)
+            return ExceptionWrapper("Error", -1, stdout)
         stdout = out.getvalue()
         self.Print(stdout)
 

--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -90,6 +90,7 @@ class MatlabKernel(MetaKernel):
         self._validated_plot_settings["size"] = tuple(
             self._matlab.get(0., "defaultfigureposition")[0][2:])
         self.handle_plot_settings()
+        return self.__matlab
 
     def do_execute_direct(self, code):
         if pipes:
@@ -248,14 +249,15 @@ class MatlabKernel(MetaKernel):
 
     def _execute_async(self, code):
         try:
-            with pipes(stdout=_PseudoStream(partial(self.Print, end="")),
-                       stderr=_PseudoStream(partial(self.Error, end=""))):
+            with pipes(stdout=_PseudoStream(partial(self.Print, sep="", end="")),
+                stderr=_PseudoStream(partial(self.Error, sep="", end=""))):
                 kwargs = { 'nargout': 0, 'async': True }
                 future = self._matlab.eval(code, **kwargs)
                 future.result()
         except (SyntaxError, MatlabExecutionError, KeyboardInterrupt) as exc:
-            stdout = exc.args[0]
-            return ExceptionWrapper("Error", -1, stdout)
+            pass
+            #stdout = exc.args[0]
+            #return ExceptionWrapper("Error", "-1", stdout)
 
     def _execute_sync(self, code):
         out = StringIO()
@@ -267,7 +269,7 @@ class MatlabKernel(MetaKernel):
         except (SyntaxError, MatlabExecutionError) as exc:
             stdout = exc.args[0]
             self.Error(stdout)
-            return ExceptionWrapper("Error", -1, stdout)
+            return ExceptionWrapper("Error", "-1", stdout)
         stdout = out.getvalue()
         self.Print(stdout)
 


### PR DESCRIPTION
Replacing those two lines with  `pass` fixed Calysto#121 for me, although it does not look good to remove error handling there.  
Returning `__matlab` at the end of `_matlab` fixed Calysto#123 for me.  
My MATLAB version is `9.5.0.944444 (R2018b)`