### PR TITLE
Fix for the figure order issue #134, copied from @robjhornby

### DIFF
--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -108,8 +108,8 @@ class MatlabKernel(MetaKernel):
                     try:
                         self._matlab.eval(
                             "arrayfun("
-                                "@(h, i) print(h, sprintf('{}/%i', i), '-d{}', '-r{}'),"
-                                "get(0, 'children'), (1:{})')".format(
+                                "@(h, i) print(h, sprintf('{}/%06i', i), '-d{}', '-r{}'),"
+                                "get(0, 'children'), ({}:-1:1)')".format(
                                     '/'.join(tmpdir.split(os.sep)),
                                     settings["format"],
                                     settings["resolution"],


### PR DESCRIPTION
This fixes ordering for inline plots so that they appear in order that they were created.  Isuue #134.  Copied from @robjhornby's fork.