### PR TITLE
FIX: issue148 (Auto completion doesn't work for table type)

### DIFF
--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -174,10 +174,11 @@ class MatlabKernel(MetaKernel):
 
         # For structs, we need to return `structname.fieldname` instead of just
         # `fieldname`, which `mtFindAllTabCompletions` does.
+        # For tables also.
 
         if "." in name:
             prefix, _ = name.rsplit(".", 1)
-            if self._matlab.eval("isstruct({})".format(prefix)):
+            if self._matlab.eval("isstruct({})".format(prefix)) or self._matlab.eval("istable({})".format(prefix)):
                 compls = ["{}.{}".format(prefix, compl) for compl in compls]
 
         return compls

--- a/matlab_kernel/kernel.py
+++ b/matlab_kernel/kernel.py
@@ -178,7 +178,7 @@ class MatlabKernel(MetaKernel):
 
         if "." in name:
             prefix, _ = name.rsplit(".", 1)
-            if self._matlab.eval("isstruct({})".format(prefix)) or self._matlab.eval("istable({})".format(prefix)):
+            if self._matlab.eval("isstruct({})".format(prefix)) | self._matlab.eval("istable({})".format(prefix)):
                 compls = ["{}.{}".format(prefix, compl) for compl in compls]
 
         return compls


### PR DESCRIPTION
## Issue
#148 

## Committed Change
Add if-option for table type data into auto-completion section(line 178) of kernel.py

## Expected Results
Auto-completion works properly with table type data.

**FROM**
Table.col[TAB]　→　colomn_name
**TO**
Table.col[TAB]　→　Table.column_name

## How to Check
Make table data.
Try TAB completion.
(with any jupyter-magic in the cell)



Thank you for your kind review.
Also, great thanks to @brunobeltran for #61 , this gave me hint for fixing.

