### PR TITLE
Stop using sys.executable when building wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,19 +12,28 @@ with open('matlab_kernel/__init__.py', 'rb') as fid:
             break
 
 DISTNAME = 'matlab_kernel'
+PY_EXECUTABLE = 'python'
+
+# when building wheels, directly use 'python' in the kernelspec.
+if any(a.startswith("bdist") for a in sys.argv):
+    PY_EXECUTABLE = 'python'
+
+# when directly installing, use sys.executable to get python full path.
+if any(a.startswith("install") for a in sys.argv):
+    PY_EXECUTABLE = sys.executable
 
 # generating kernel.json for both kernels
 os.makedirs(os.path.join(DISTNAME, 'matlab'), exist_ok=True)
 with open(os.path.join(DISTNAME, 'kernel_template.json'), 'r') as fp:
     matlab_json = json.load(fp)
-matlab_json['argv'][0] = sys.executable
+matlab_json['argv'][0] = PY_EXECUTABLE
 with open(os.path.join(DISTNAME, 'matlab','kernel.json'), 'w') as fp:
     json.dump(matlab_json, fp)
 
 os.makedirs(os.path.join(DISTNAME, 'matlab_connect'), exist_ok=True)
 with open(os.path.join(DISTNAME, 'kernel_template.json'), 'r') as fp:
     matlab_json = json.load(fp)
-matlab_json['argv'][0] = sys.executable
+matlab_json['argv'][0] = PY_EXECUTABLE
 matlab_json['display_name'] = 'Matlab (Connection)'
 matlab_json['name'] = "matlab_connect"
 matlab_json['env'] = {'connect-to-existing-kernel': '1'}


### PR DESCRIPTION
Handle issue #160 .

I didn't realize `sys.executable` cannot be used if wheels were built on a different computer. In this patch, the `argv` is `sys.executable` only when directly installing from source,  and remains `python` when building wheels. 